### PR TITLE
fix ockam config definition for kafka portals

### DIFF
--- a/internal/impl/ockam/node.go
+++ b/internal/impl/ockam/node.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"math/rand"
 	"os/exec"
+	"strings"
 	"time"
 )
 
@@ -70,5 +71,5 @@ func (n *Node) IsRunning() bool {
 		return false
 	}
 
-	return status == "Up"
+	return strings.ToLower(status) == "up"
 }

--- a/internal/impl/ockam/output_kafka.go
+++ b/internal/impl/ockam/output_kafka.go
@@ -90,18 +90,18 @@ func newOckamKafkaOutput(conf *service.ParsedConfig, log *service.Logger) (*ocka
 
 	nodeConfig := `
 		{
-			"ticket": ` + ticket + `,
+			"ticket": "` + ticket + `",
 
-			"kafka-inlets": [{
-				"from": ` + kafkaInletAddress + `,
-				"to": /secure/api,
-				"consumer": ` + routeToConsumer + `,
-				"avoid-publishing": true,
-			}]
+			"kafka-inlet": [{
+				"from": "` + kafkaInletAddress + `",
+				"to": "/secure/api",
+				"consumer": "` + routeToConsumer + `",
+				"avoid-publishing": true
+			}],
 
-			"kafka-outlets": [{
+			"kafka-outlet": [{
 				"bootstrap-server": "` + bootstrapServer + `",
-				"tls": "` + strconv.FormatBool(tls) + `",
+				"tls": ` + strconv.FormatBool(tls) + `
 			}]
 		}
 	`


### PR DESCRIPTION
```yaml
# producer.yaml

input:
  stdin: {}

output:
  ockam_kafka:
    ockam_ticket: "output.ticket"
    ockam_route_to_consumer: /dnsaddr/localhost/tcp/4000
    seed_brokers: [ localhost:9092 ]
    topic: topic_A
```


```yaml
# consumer.yaml

http:
  address: 0.0.0.0:4196

input:
  ockam_kafka:
    ockam_ticket: "input.ticket"
    ockam_consumer_port: 4000
    seed_brokers: [ localhost:9092 ]
    topics: [ topic_A ]
    consumer_group: example_group

pipeline:
  threads: 5
  processors:
    - bloblang: |
        root.doc = this | content().string()
        root.length = content().length()
        root.topic = meta("kafka_topic")
        root.sleep = random_int(max:10)

output:
  stdout: {}
```