### PR TITLE
run ockam in foreground, logs to benthos

### DIFF
--- a/internal/impl/ockam/command.go
+++ b/internal/impl/ockam/command.go
@@ -1,0 +1,87 @@
+package ockam
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+)
+
+func InstallCommand() error {
+	// Download the install script.
+	resp, err := http.Get("https://install.command.ockam.io")
+	if err != nil {
+		return fmt.Errorf("failed to download the install script: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("got HTTP response with status code != 200, while downloading the install script: %v", resp.StatusCode)
+	}
+
+	// Save the install script to a temporary file.
+	tmpFile, err := os.CreateTemp("", "install-ockam-*.sh")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary file for the install script: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	_, err = io.Copy(tmpFile, resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to copy install script to a temporary file: %v", err)
+	}
+	err = os.Chmod(tmpFile.Name(), 0700)
+	if err != nil {
+		return fmt.Errorf("failed to change permissions onthe install script to 0700: %v", err)
+	}
+
+	// Run the install script.
+	return RunCommand(tmpFile.Name())
+}
+
+func IsCommandInPath() bool {
+	_, err := exec.LookPath("ockam")
+	return err == nil
+}
+
+func RunCommand(name string, arg ...string) error {
+	quotedArgs := make([]string, len(arg))
+	for i, a := range arg {
+		quotedArgs[i] = fmt.Sprintf("'%s'", a)
+	}
+
+	cmd := exec.Command("sh", "-c", "source ~/.ockam/env && "+name+" "+strings.Join(quotedArgs, " "))
+
+	stdout, err := os.CreateTemp("", "stdout-*.log")
+	if err != nil {
+		return fmt.Errorf("failed to create a temporary file to store the command's stdout: %v", err)
+	}
+	defer stdout.Close()
+
+	stderr, err := os.CreateTemp("", "stderr-*.log")
+	if err != nil {
+		return fmt.Errorf("failed to create a temporary file to store the command's stderr: %v", err)
+	}
+	defer stderr.Close()
+
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
+	cmd.Env = append(os.Environ(),
+		"NO_INPUT=true",
+		"NO_COLOR=true",
+		"OCKAM_DISABLE_UPGRADE_CHECK=true",
+		"OCKAM_OPENTELEMETRY_EXPORT=false",
+	)
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+	err = cmd.Run()
+	if err != nil {
+		errMsg := "failed to run the command: " + cmd.String() + ", error: " + err.Error() + "\n" +
+			"stdout log file: " + stdout.Name() + "\n" +
+			"stderr log file: " + stderr.Name()
+		return errors.New(errMsg)
+	}
+
+	return nil
+}

--- a/internal/impl/ockam/command_test.go
+++ b/internal/impl/ockam/command_test.go
@@ -1,0 +1,1 @@
+package ockam_test

--- a/internal/impl/ockam/input_kafka.go
+++ b/internal/impl/ockam/input_kafka.go
@@ -1,0 +1,124 @@
+package ockam
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/benthosdev/benthos/v4/internal/impl/kafka"
+	"github.com/benthosdev/benthos/v4/public/service"
+)
+
+func ockamKafkaInputConfig() *service.ConfigSpec {
+	return kafka.FranzKafkaInputConfig().
+		Summary(`Ockam`).
+		Field(service.NewStringField("ockam_ticket")).
+		Field(service.NewStringField("ockam_node_address").Optional())
+}
+
+// this function is, almost, an exact copy of the init() function in ../kafka/input_kafka_franz.go
+func init() {
+	err := service.RegisterBatchInput("ockam_kafka", ockamKafkaInputConfig(),
+		func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
+			i, err := newOckamKafkaInput(conf, mgr)
+			if err != nil {
+				return nil, err
+			}
+			return service.AutoRetryNacksBatchedToggled(conf, i.kafkaReader)
+		})
+	if err != nil {
+		panic(err)
+	}
+}
+
+//------------------------------------------------------------------------------
+
+type ockamKafkaInput struct {
+	kafkaReader *kafka.FranzKafkaReader
+	node        Node
+}
+
+func newOckamKafkaInput(conf *service.ParsedConfig, mgr *service.Resources) (*ockamKafkaInput, error) {
+	kafkaReader, err := kafka.NewFranzKafkaReaderFromConfig(conf, mgr)
+	if err != nil {
+		return nil, err
+	}
+
+	_, tls, err := conf.FieldTLSToggled("tls")
+	if err != nil {
+		tls = false
+	}
+
+	ticket, err := conf.FieldString("ockam_ticket")
+	if err != nil {
+		return nil, err
+	}
+
+	nodePort, err := conf.FieldString("ockam_node_address")
+	if err != nil {
+		listener, err := net.Listen("tcp", "127.0.0.1:0")
+		if err != nil {
+			return nil, err
+		}
+		nodePort = strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+		_ = listener.Close()
+	}
+	mgr.Logger().Infof("The Ockam consumer is listening on port %v", nodePort)
+
+	// Find a free port to use for the kafka-inlet
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	kafkaInletPort := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+	kafkaInletAddress := "127.0.0.1:" + kafkaInletPort
+	_ = listener.Close()
+
+	// Override SeedBrokers list that would be used by kafka_franz to be the kafka inlet address
+	kafkaReader.SeedBrokers = []string{kafkaInletAddress}
+
+	// Use the first "seed_brokers" field item as the bootstrapServer argument for Ockam.
+	seedBrokers, err := conf.FieldStringList("seed_brokers")
+	if err != nil {
+		return nil, err
+	}
+	bootstrapServer := strings.Split(seedBrokers[0], ",")[0]
+
+	nodeConfig := `
+		{
+			"ticket": "` + ticket + `",
+			"tcp-listener-address": "0.0.0.0:` + nodePort + `",
+
+			"kafka-inlet": [{
+				"from": "` + kafkaInletAddress + `",
+				"to": "/secure/api",
+				"avoid-publishing": true
+			}],
+
+			"kafka-outlet": [{
+				"bootstrap-server": "` + bootstrapServer + `",
+				"tls": ` + strconv.FormatBool(tls) + `
+			}]
+		}
+	`
+	node, err := NewNode(nodeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ockamKafkaInput{kafkaReader, *node}, nil
+}
+
+func (o *ockamKafkaInput) Connect(ctx context.Context) error {
+	return o.kafkaReader.Connect(ctx)
+}
+
+func (o *ockamKafkaInput) ReadBatch(ctx context.Context) (service.MessageBatch, service.AckFunc, error) {
+	return o.kafkaReader.ReadBatch(ctx)
+}
+
+func (o *ockamKafkaInput) Close(ctx context.Context) error {
+	return errors.Join(o.kafkaReader.Close(ctx), o.node.Delete())
+}

--- a/internal/impl/ockam/input_kafka_test.go
+++ b/internal/impl/ockam/input_kafka_test.go
@@ -1,0 +1,1 @@
+package ockam_test

--- a/internal/impl/ockam/node.go
+++ b/internal/impl/ockam/node.go
@@ -1,25 +1,29 @@
 package ockam
 
 import (
+	"bufio"
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os/exec"
 	"strings"
 	"time"
+
+	"regexp"
+
+	"github.com/benthosdev/benthos/v4/public/service"
 )
 
+
+
 type Node struct {
+	OckamBin string
 	Name   string
 	Config string
 }
 
-func NewNode(config string) (*Node, error) {
-	var cfg map[string]interface{}
-	err := json.Unmarshal([]byte(config), &cfg)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshall config as json: %v", err)
-	}
+func NewNode(ockam_bin string, cfg map[string]interface{}, log *service.Logger) (*Node, error) {
 
 	name := "benthos-" + generateName()
 	cfg["name"] = name
@@ -29,9 +33,9 @@ func NewNode(config string) (*Node, error) {
 		return nil, fmt.Errorf("failed to marshal updated config to json string: %v", err)
 	}
 
-	node := &Node{Name: name, Config: string(updatedConfig)}
+	node := &Node{OckamBin: ockam_bin, Name: name, Config: string(updatedConfig)}
 
-	err = node.Create()
+	err = node.Create(log)
 	if err != nil {
 		return nil, err
 	}
@@ -45,8 +49,55 @@ func generateName() string {
 	return fmt.Sprintf("%08x", randomNumber)
 }
 
+/*
 func (n *Node) Create() error {
 	return RunCommand("ockam", "node", "create", "--node-config", n.Config)
+}
+*/
+func (n *Node) Create(log *service.Logger) error {
+	//return RunCommand("ockam", "node", "create", "--node-config", n.Config)
+
+	ctx, _ := context.WithCancel(context.Background())
+
+	// Run ockam in foreground, piping its log into benthos.  Ockam process exit whenever benthos exit.
+	// TODO: LOG_LEVEL should be set at the value set on benthos, otherwise we are wasting cpu logging at
+	// debug level just to be discarded latter.
+	fmt.Printf("Command: %s : %s", n.OckamBin, n.Config)
+	cmd := exec.CommandContext(ctx, n.OckamBin, "node", "create", "-f", "--node-config", n.Config )
+	cmd.Env = []string{"OCKAM_LOGGING=true", "OCKAM_LOG_LEVEL=debug", "CONSUMER_IDENTIFIER=11", "PRODUCER_IDENTIFIER=11"}
+	stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return err
+		}
+	scanner := bufio.NewScanner(stdout)
+	splitter := regexp.MustCompile(`\s+`)
+	go func() {
+		// Just pipe the logs from ockam into benthos
+		for scanner.Scan() {
+			// timestamp level line
+			log_fields := splitter.Split(scanner.Text(), 3)
+			if len(log_fields) == 3 {
+				switch log_fields[1] {
+				case "DEBUG":
+					log.Debugf(log_fields[2])
+				case "INFO":
+					log.Infof(log_fields[2])
+				case "WARN":
+					log.Warnf(log_fields[2])
+				case "ERROR":
+					log.Errorf(log_fields[2])
+				}
+			}
+		}
+		if scanner.Err() != nil {
+			cmd.Process.Kill()
+			cmd.Wait()
+			log.Errorf("%v", scanner.Err())
+			return
+		}
+		cmd.Wait()
+	}()
+	return cmd.Start()
 }
 
 func (n *Node) Delete() error {

--- a/internal/impl/ockam/node.go
+++ b/internal/impl/ockam/node.go
@@ -1,0 +1,75 @@
+package ockam
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+type Node struct {
+	Name   string
+	Config string
+}
+
+func NewNode(config string) (*Node, error) {
+	var cfg map[string]interface{}
+	err := json.Unmarshal([]byte(config), &cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to unmarshall config as json: %v", err)
+	}
+
+	name := "benthos-" + generateName()
+	cfg["name"] = name
+
+	updatedConfig, err := json.Marshal(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal updated config to json string: %v", err)
+	}
+
+	node := &Node{Name: name, Config: string(updatedConfig)}
+
+	err = node.Create()
+	if err != nil {
+		return nil, err
+	}
+
+	return node, nil
+}
+
+func generateName() string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	randomNumber := r.Intn(1 << 32)
+	return fmt.Sprintf("%08x", randomNumber)
+}
+
+func (n *Node) Create() error {
+	return RunCommand("ockam", "node", "create", "--node-config", n.Config)
+}
+
+func (n *Node) Delete() error {
+	return RunCommand("ockam", "node", "delete", n.Name, "--yes")
+}
+
+func (n *Node) IsRunning() bool {
+	cmd := exec.Command("ockam", "node", "show", n.Name, "--output", "json")
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+
+	var result map[string]interface{}
+	err = json.Unmarshal(output, &result)
+	if err != nil {
+		return false
+	}
+
+	status, ok := result["status"].(string)
+	if !ok {
+		return false
+	}
+
+	return strings.ToLower(status) == "up"
+}

--- a/internal/impl/ockam/node_test.go
+++ b/internal/impl/ockam/node_test.go
@@ -1,0 +1,39 @@
+package ockam_test
+
+import (
+	"testing"
+
+	"github.com/benthosdev/benthos/v4/internal/impl/ockam"
+)
+
+func TestNodeCreate(t *testing.T) {
+	config := `
+		{
+			"tcp-outlets": {
+				"an-outlet": {
+					"to": 9999
+				}
+			}
+		}
+	`
+
+	node, err := ockam.NewNode(config)
+	if err != nil {
+		t.Error("failed to create a node, error: ", err)
+	}
+
+	isRunning := node.IsRunning()
+	if !isRunning {
+		t.Error("node is not running")
+	}
+
+	err = node.Delete()
+	if err != nil {
+		t.Error("failed to delete the node")
+	}
+
+	isRunning = node.IsRunning()
+	if isRunning {
+		t.Error("node is still running, after being deleted")
+	}
+}

--- a/internal/impl/ockam/output_kafka.go
+++ b/internal/impl/ockam/output_kafka.go
@@ -1,0 +1,126 @@
+package ockam
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strconv"
+	"strings"
+
+	"github.com/benthosdev/benthos/v4/internal/impl/kafka"
+	"github.com/benthosdev/benthos/v4/public/service"
+)
+
+func ockamKafkaOutputConfig() *service.ConfigSpec {
+	return kafka.FranzKafkaOutputConfig().
+		Summary("Ockam").
+		Field(service.NewStringField("ockam_ticket")).
+		Field(service.NewStringField("ockam_route_to_consumer"))
+}
+
+// this function is, almost, an exact copy of the init() function in ../kafka/output_kafka_franz.go
+func init() {
+	err := service.RegisterBatchOutput("ockam_kafka", ockamKafkaOutputConfig(),
+		func(conf *service.ParsedConfig, mgr *service.Resources) (
+			output service.BatchOutput,
+			batchPolicy service.BatchPolicy,
+			maxInFlight int,
+			err error,
+		) {
+			if maxInFlight, err = conf.FieldInt("max_in_flight"); err != nil {
+				return
+			}
+			if batchPolicy, err = conf.FieldBatchPolicy("batching"); err != nil {
+				return
+			}
+			output, err = newOckamKafkaOutput(conf, mgr.Logger())
+			return
+		})
+	if err != nil {
+		panic(err)
+	}
+}
+
+//------------------------------------------------------------------------------
+
+type ockamKafkaOutput struct {
+	kafkaWriter *kafka.FranzKafkaWriter
+	node        Node
+}
+
+func newOckamKafkaOutput(conf *service.ParsedConfig, log *service.Logger) (*ockamKafkaOutput, error) {
+	kafkaWriter, err := kafka.NewFranzKafkaWriterFromConfig(conf, log)
+	if err != nil {
+		return nil, err
+	}
+
+	_, tls, err := conf.FieldTLSToggled("tls")
+	if err != nil {
+		tls = false
+	}
+
+	ticket, err := conf.FieldString("ockam_ticket")
+	if err != nil {
+		return nil, err
+	}
+
+	routeToConsumer, err := conf.FieldString("ockam_route_to_consumer")
+	if err != nil {
+		return nil, err
+	}
+
+	// Find a free port to use for the kafka-inlet
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, err
+	}
+	kafkaInletPort := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+	kafkaInletAddress := "127.0.0.1:" + kafkaInletPort
+	_ = listener.Close()
+
+	// Override seed_brokers conf that would be used by kafka_franz to be the kafka inlet address
+	kafkaWriter.SeedBrokers = []string{kafkaInletAddress}
+
+	// Use the first "seed_brokers" field item as the bootstrapServer argument for Ockam.
+	seedBrokers, err := conf.FieldStringList("seed_brokers")
+	if err != nil {
+		return nil, err
+	}
+	bootstrapServer := strings.Split(seedBrokers[0], ",")[0]
+
+	nodeConfig := `
+		{
+			"ticket": "` + ticket + `",
+
+			"kafka-inlet": [{
+				"from": "` + kafkaInletAddress + `",
+				"to": "/secure/api",
+				"consumer": "` + routeToConsumer + `",
+				"avoid-publishing": true
+			}],
+
+			"kafka-outlet": [{
+				"bootstrap-server": "` + bootstrapServer + `",
+				"tls": ` + strconv.FormatBool(tls) + `
+			}]
+		}
+	`
+	node, err := NewNode(nodeConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ockamKafkaOutput{kafkaWriter, *node}, nil
+}
+
+func (o *ockamKafkaOutput) Connect(ctx context.Context) error {
+	return o.kafkaWriter.Connect(ctx)
+}
+
+func (o *ockamKafkaOutput) WriteBatch(ctx context.Context, batch service.MessageBatch) error {
+	return o.kafkaWriter.WriteBatch(ctx, batch)
+}
+
+func (o *ockamKafkaOutput) Close(ctx context.Context) error {
+	return errors.Join(o.kafkaWriter.Close(ctx), o.node.Delete())
+}

--- a/internal/impl/ockam/output_kafka_test.go
+++ b/internal/impl/ockam/output_kafka_test.go
@@ -1,0 +1,1 @@
+package ockam_test

--- a/public/components/all/package.go
+++ b/public/components/all/package.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/benthosdev/benthos/v4/public/components/nanomsg"
 	_ "github.com/benthosdev/benthos/v4/public/components/nats"
 	_ "github.com/benthosdev/benthos/v4/public/components/nsq"
+	_ "github.com/benthosdev/benthos/v4/public/components/ockam"
 	_ "github.com/benthosdev/benthos/v4/public/components/opensearch"
 	_ "github.com/benthosdev/benthos/v4/public/components/otlp"
 	_ "github.com/benthosdev/benthos/v4/public/components/prometheus"

--- a/public/components/ockam/package.go
+++ b/public/components/ockam/package.go
@@ -1,0 +1,6 @@
+package ockam
+
+import (
+	// Bring in the internal plugin definitions.
+	_ "github.com/benthosdev/benthos/v4/internal/impl/ockam"
+)


### PR DESCRIPTION
Some exploratory testing of ideas for the plugin

## Changes

* [Config as map](https://github.com/build-trust/benthos/blob/e1a12e6912645b5baaf098b7801d09b2da4552c6/internal/impl/ockam/input_kafka.go#L94-L106) instead of building json string by hand
* Added the identifiers to setup trust
* Added optional ockam binary path for testing (simpler for me, but not sure if that should stay)
* Start ockam in [foreground rather than background](https://github.com/build-trust/benthos/blob/e1a12e6912645b5baaf098b7801d09b2da4552c6/internal/impl/ockam/node.go#L66).   [Consume it streams of logs and pipe them back into benthos](https://github.com/build-trust/benthos/blob/e1a12e6912645b5baaf098b7801d09b2da4552c6/internal/impl/ockam/node.go#L74-L89) at the correct log level  (warning:  if using   `benthos -log.level debug` benthos' output on console  will be hard to follow because the amount of log we do at that level.   but using `log.level info` and upwards is fine and shows how ockam' logs get ingested in benthos' system)

How to run it:

(assuming there is an identity called `consumer` and one called `producer`, and redpanda listening on port 9092)


## Consumer 

### benthos config
```
http:
  address: 0.0.0.0:4196
input:
  ockam_kafka:
    seed_brokers: [  localhost:9092 ]
    topics: [ topic_A ]
    consumer_group: example_group
    consumer_identifier: ${CONSUMER_IDENTIFIER}
    producer_identifier: ${PRODUCER_IDENTIFIER}
    ockam_binary_path: ${OCKAM}

pipeline:
  threads: 5
  processors:
    - bloblang: |
        root.doc = this | content().string()
        root.length = content().length()
        root.topic = meta("kafka_topic")
        root.sleep = random_int(max:10)

output:
  stdout: {}

```

### Run consumer

```
OCKAM=path-to-your-ockam (or don't set the ockam_binary_path conf on benthos' plugin, to use default ockam from path)
consumer=$($OCKAM identity show consumer)
producer=$($OCKAM identity show producer)
OCKAM=$OCKAM CONSUMER_IDENTIFIER=$consumer  PRODUCER_IDENTIFIER=$producer  \
    benthos -log.level info -c consumer.yaml
```


## Producer

### benthos config
```
input:
  stdin: {}

output:
  ockam_kafka:
    seed_brokers: [ localhost:9092 ]
    topic: topic_A
    consumer_identifier: ${CONSUMER_IDENTIFIER}
    producer_identifier: ${PRODUCER_IDENTIFIER}
    ockam_route_to_consumer: /dnsaddr/localhost/tcp/4000
    ockam_binary_path: ${OCKAM}
```

### Run producer:
```
OCKAM=path-to-your-ockam (or don't set the ockam_binary_path conf on benthos' plugin, to use default ockam from path)
consumer=$($OCKAM identity show consumer)
producer=$($OCKAM identity show producer)
OCKAM=$OCKAM CONSUMER_IDENTIFIER=$consumer  PRODUCER_IDENTIFIER=$producer  \
    benthos -log.level info -c producer.yaml
```