### PR TITLE
fix: register ockam input plugin correctly

### DIFF
--- a/internal/impl/ockam/input_kafka.go
+++ b/internal/impl/ockam/input_kafka.go
@@ -17,7 +17,7 @@ func init() {
 			if err != nil {
 				return nil, err
 			}
-			return service.AutoRetryNacksBatchedToggled(conf, i.kafkaReader)
+			return service.AutoRetryNacksBatchedToggled(conf, i)
 		})
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
It was registering the underlying kafka plugin, which means that the ockam plugin `connect/read/close` methods were not being called, and the node was not being deleted after exiting the process.