### PR TITLE
feat: read the seed_brokers from the RPK_BROKERS variable if defined.

### DIFF
--- a/internal/impl/kafka/output_kafka_franz.go
+++ b/internal/impl/kafka/output_kafka_franz.go
@@ -16,7 +16,7 @@ import (
 	"github.com/benthosdev/benthos/v4/public/service"
 )
 
-func franzKafkaOutputConfig() *service.ConfigSpec {
+func FranzKafkaOutputConfig() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Beta().
 		Categories("Services").
@@ -94,7 +94,7 @@ root = if this.partitioner == "manual" {
 }
 
 func init() {
-	err := service.RegisterBatchOutput("kafka_franz", franzKafkaOutputConfig(),
+	err := service.RegisterBatchOutput("kafka_franz", FranzKafkaOutputConfig(),
 		func(conf *service.ParsedConfig, mgr *service.Resources) (
 			output service.BatchOutput,
 			batchPolicy service.BatchPolicy,
@@ -107,7 +107,7 @@ func init() {
 			if batchPolicy, err = conf.FieldBatchPolicy("batching"); err != nil {
 				return
 			}
-			output, err = newFranzKafkaWriterFromConfig(conf, mgr.Logger())
+			output, err = NewFranzKafkaWriterFromConfig(conf, mgr.Logger())
 			return
 		})
 	if err != nil {
@@ -117,8 +117,8 @@ func init() {
 
 //------------------------------------------------------------------------------
 
-type franzKafkaWriter struct {
-	seedBrokers      []string
+type FranzKafkaWriter struct {
+	SeedBrokers      []string
 	topicStr         string
 	topic            *service.InterpolatedString
 	key              *service.InterpolatedString
@@ -139,8 +139,8 @@ type franzKafkaWriter struct {
 	log *service.Logger
 }
 
-func newFranzKafkaWriterFromConfig(conf *service.ParsedConfig, log *service.Logger) (*franzKafkaWriter, error) {
-	f := franzKafkaWriter{
+func NewFranzKafkaWriterFromConfig(conf *service.ParsedConfig, log *service.Logger) (*FranzKafkaWriter, error) {
+	f := FranzKafkaWriter{
 		log: log,
 	}
 
@@ -149,7 +149,7 @@ func newFranzKafkaWriterFromConfig(conf *service.ParsedConfig, log *service.Logg
 		return nil, err
 	}
 	for _, b := range brokerList {
-		f.seedBrokers = append(f.seedBrokers, strings.Split(b, ",")...)
+		f.SeedBrokers = append(f.SeedBrokers, strings.Split(b, ",")...)
 	}
 
 	if f.topic, err = conf.FieldInterpolatedString("topic"); err != nil {
@@ -266,13 +266,13 @@ func newFranzKafkaWriterFromConfig(conf *service.ParsedConfig, log *service.Logg
 
 //------------------------------------------------------------------------------
 
-func (f *franzKafkaWriter) Connect(ctx context.Context) error {
+func (f *FranzKafkaWriter) Connect(ctx context.Context) error {
 	if f.client != nil {
 		return nil
 	}
 
 	clientOpts := []kgo.Opt{
-		kgo.SeedBrokers(f.seedBrokers...),
+		kgo.SeedBrokers(f.SeedBrokers...),
 		kgo.SASL(f.saslConfs...),
 		kgo.AllowAutoTopicCreation(), // TODO: Configure this
 		kgo.ProducerBatchMaxBytes(f.produceMaxBytes),
@@ -303,7 +303,7 @@ func (f *franzKafkaWriter) Connect(ctx context.Context) error {
 	return nil
 }
 
-func (f *franzKafkaWriter) WriteBatch(ctx context.Context, b service.MessageBatch) (err error) {
+func (f *FranzKafkaWriter) WriteBatch(ctx context.Context, b service.MessageBatch) (err error) {
 	if f.client == nil {
 		return service.ErrNotConnected
 	}
@@ -351,7 +351,7 @@ func (f *franzKafkaWriter) WriteBatch(ctx context.Context, b service.MessageBatc
 	return
 }
 
-func (f *franzKafkaWriter) disconnect() {
+func (f *FranzKafkaWriter) disconnect() {
 	if f.client == nil {
 		return
 	}
@@ -359,7 +359,7 @@ func (f *franzKafkaWriter) disconnect() {
 	f.client = nil
 }
 
-func (f *franzKafkaWriter) Close(ctx context.Context) error {
+func (f *FranzKafkaWriter) Close(ctx context.Context) error {
 	f.disconnect()
 	return nil
 }

--- a/internal/impl/ockam/command.go
+++ b/internal/impl/ockam/command.go
@@ -59,6 +59,8 @@ func runCommand(capture bool, arg ...string) (string, string, error) {
 	return stdout, stderr, nil
 }
 
+// Returns the path to the Ockam Command binary.
+// If it's not found, it will be downloaded and installed.
 func setupCommand() (string, error) {
 	bin, err := findCommandBinary()
 	if err == nil {
@@ -70,12 +72,7 @@ func setupCommand() (string, error) {
 		return "", fmt.Errorf("failed to install Ockam Command: %v", err)
 	}
 
-	bin, err = findCommandBinary()
-	if err != nil {
-		return "", fmt.Errorf("failed to find Ockam Command: %v", err)
-	}
-
-	return bin, nil
+	return findCommandBinary()
 }
 
 // Returns the path to the Ockam Command binary or an error if it can't find the binary.

--- a/internal/impl/ockam/command.go
+++ b/internal/impl/ockam/command.go
@@ -1,0 +1,300 @@
+package ockam
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+)
+
+// Run `ockam ...` commands
+func runCommand(capture bool, arg ...string) (string, string, error) {
+	bin, err := findCommandBinary()
+	if err != nil {
+		return "", "", fmt.Errorf("failed to find Ockam Command binary: %v", err)
+	}
+
+	cmd := exec.Command(bin, arg...)
+	cmd.Env = append(os.Environ(),
+		"NO_INPUT=true",
+		"NO_COLOR=true",
+		"OCKAM_DISABLE_UPGRADE_CHECK=true",
+		"OCKAM_OPENTELEMETRY_EXPORT=false",
+	)
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	if capture {
+		cmd.Stdout = &stdoutBuf
+		cmd.Stderr = &stderrBuf
+	} else {
+		devNull, err := os.Open(os.DevNull)
+		if err != nil {
+			return "", "", fmt.Errorf("failed to open %s: %v", os.DevNull, err)
+		}
+		defer devNull.Close()
+
+		cmd.Stdout = devNull
+		cmd.Stderr = devNull
+	}
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+
+	err = cmd.Run()
+	stdout := stdoutBuf.String()
+	stderr := stderrBuf.String()
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to run the command: %s, error: %v\nstdout:\n%s\nstderr:\n%s",
+			cmd.String(), err, stdout, stderr)
+		return stdout, stderr, errors.New(errMsg)
+	}
+
+	return stdout, stderr, nil
+}
+
+func setupCommand() (string, error) {
+	bin, err := findCommandBinary()
+	if err == nil {
+		return bin, nil
+	}
+
+	err = installCommand()
+	if err != nil {
+		return "", fmt.Errorf("failed to install Ockam Command: %v", err)
+	}
+
+	bin, err = findCommandBinary()
+	if err != nil {
+		return "", fmt.Errorf("failed to find Ockam Command: %v", err)
+	}
+
+	return bin, nil
+}
+
+// Returns the path to the Ockam Command binary or an error if it can't find the binary.
+func findCommandBinary() (string, error) {
+	// If the OCKAM environment variable is set, assume that as the path of the Ockam Command binary.
+	command := os.Getenv("OCKAM")
+	if command != "" {
+		return command, nil
+	}
+
+	// If ockam is in path, assume that as the Ockam Command binary.
+	_, err := exec.LookPath("ockam")
+	if err == nil {
+		return "ockam", nil
+	}
+
+	// Try to find the path of Ockam Command by running `command -v ockam`
+	shell, err := shell()
+	if err == nil {
+		cmdToFindBinary := "command -v ockam"
+
+		// If ockamHome()/env file is present and readable, source it before running `command -v ockam`
+		// This may be helpful when Ockam Command was installed using the Ockam Command install script.
+		envFile, err := envFile()
+		if err == nil {
+			cmdToFindBinary = "source " + envFile + " && " + cmdToFindBinary
+		}
+
+		cmd := exec.Command(shell, "-c", cmdToFindBinary)
+		output, err := cmd.Output()
+		if err == nil {
+			path := strings.TrimSpace(string(output))
+			if path != "" {
+				return path, nil
+			}
+		}
+	}
+
+	// If ockamHome() + "/bin/ockam" exists, return its path
+	path := ockamHome() + "/bin/ockam"
+	_, err = os.Stat(path)
+	if err == nil {
+		return path, nil
+	}
+
+	return "", errors.New("failed to find Ockam Command binary")
+}
+
+// Installs Ockam Command.
+//
+// If bash is not available, directly download and install the binary.
+// If bash is available, install using the install script.
+func installCommand() error {
+	_, err := exec.LookPath("bash")
+	if err != nil {
+		return downloadAndInstall()
+	} else {
+		return downloadAndInstallWithInstallScript()
+	}
+}
+
+func downloadAndInstall() error {
+	binaryType, err := pickBinaryType()
+	if err != nil {
+		return err
+	}
+	url := "https://github.com/build-trust/ockam/releases/latest/download/ockam." + binaryType
+
+	version := os.Getenv("OCKAM_VERSION")
+	if version != "" {
+		url = "https://github.com/build-trust/ockam/releases/download/ockam_" + version + "/ockam." + binaryType
+	}
+
+	resp, err := http.Get(url)
+	if err != nil {
+		return fmt.Errorf("failed to download the binary %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("got HTTP response with status code != 200, while downloading %s: %v", url, resp.StatusCode)
+	}
+
+	binary := ockamHome() + "/bin/ockam"
+	out, err := os.Create(binary)
+	if err != nil {
+		return fmt.Errorf("failed to create file %s: %v", binary, err)
+	}
+	defer out.Close()
+
+	_, err = io.Copy(out, resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to copy downloaded contents to file %s: %v", binary, err)
+	}
+
+	err = os.Chmod(binary, 0700)
+	if err != nil {
+		return fmt.Errorf("failed to change permissions of the file %s: %v", binary, err)
+	}
+	return nil
+}
+
+func pickBinaryType() (string, error) {
+	binaries := map[string]string{
+		"darwin/arm64": "aarch64-apple-darwin",
+		"darwin/amd64": "x86_64-apple-darwin",
+		"linux/arm64":  "aarch64-unknown-linux-musl",
+		"linux/armv7":  "armv7-unknown-linux-musleabihf",
+		"linux/amd64":  "x86_64-unknown-linux-gnu",
+	}
+
+	os := runtime.GOOS
+	arch := runtime.GOARCH
+	binary, exists := binaries[fmt.Sprintf("%s/%s", os, arch)]
+	if !exists {
+		return "", fmt.Errorf("no available binary for: %s/%s", os, arch)
+	}
+
+	return binary, nil
+}
+
+func downloadAndInstallWithInstallScript() error {
+	// Download the install script.
+	resp, err := http.Get("https://install.command.ockam.io")
+	if err != nil {
+		return fmt.Errorf("failed to download the install script: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("got HTTP response with status code != 200, while downloading the install script: %v", resp.StatusCode)
+	}
+
+	// Save the install script to a temporary file.
+	tmpFile, err := os.CreateTemp("", "install-ockam-*.sh")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary file for the install script: %v", err)
+	}
+	defer os.Remove(tmpFile.Name())
+	_, err = io.Copy(tmpFile, resp.Body)
+	if err != nil {
+		return fmt.Errorf("failed to copy install script to a temporary file: %v", err)
+	}
+	err = os.Chmod(tmpFile.Name(), 0700)
+	if err != nil {
+		return fmt.Errorf("failed to change permissions on the install script to 0700: %v", err)
+	}
+
+	// Prepare the install script invocation command
+	c := []string{tmpFile.Name()}
+	version := os.Getenv("OCKAM_VERSION")
+	if version != "" {
+		c = append(c, "--version", version)
+	}
+
+	// Run the install script
+	cmd := exec.Command("bash", c...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err = cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to execute the install script: %v", err)
+	}
+
+	return nil
+}
+
+// Returns the name of a shell executable, "bash" or "sh".
+//
+// It returns the name of a shell only if an executable with that name is found in $PATH.
+// Returns an error of neither bash or sh are found in $PATH. Which may happen in environments like a docker container.
+func shell() (string, error) {
+	shells := []string{"bash", "sh"}
+	for _, s := range shells {
+		_, err := exec.LookPath(s)
+		if err == nil {
+			return s, nil
+		}
+	}
+	return "", errors.New("failed to find bash or sh in path")
+}
+
+// Returns the path to the environment file that is used to add Ockam Command to $PATH, in a shell.
+//
+// This file may be found at ockamHome()/env. This function first tries to open the file at that path in read-only mode.
+// If opening the env file succeeds, this function returns its path, otherwise it returns an error.
+func envFile() (string, error) {
+	envFile := ockamHome() + "/env"
+
+	// Check if the env file can be opened for reading
+	file, err := os.Open(envFile)
+	if err != nil {
+		return "", fmt.Errorf("failed to open env file %s: %v", envFile, err)
+	}
+	defer file.Close()
+
+	return envFile, nil
+}
+
+// Returns the path to Ockam Command's home directory.
+func ockamHome() string {
+	home := os.Getenv("OCKAM_HOME")
+	if home != "" {
+		return home
+	}
+
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return ".ockam"
+	}
+
+	return filepath.Join(homeDir, ".ockam")
+}
+
+func findAvailableLocalTCPAddress() (string, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return "", err
+	}
+	address := listener.Addr().String()
+	_ = listener.Close()
+
+	return address, nil
+}

--- a/internal/impl/ockam/command.go
+++ b/internal/impl/ockam/command.go
@@ -295,3 +295,12 @@ func findAvailableLocalTCPAddress() (string, error) {
 
 	return address, nil
 }
+
+func localTCPAddressIsTaken(address string) bool {
+	listener, err := net.Listen("tcp", address)
+	if err != nil {
+		return true
+	}
+	_ = listener.Close()
+	return false
+}

--- a/internal/impl/ockam/input_kafka.go
+++ b/internal/impl/ockam/input_kafka.go
@@ -30,7 +30,7 @@ func ockamKafkaInputConfig() *service.ConfigSpec {
 		Field(service.NewStringField("ockam_identity_name").Optional()).
 		Field(service.NewStringField("ockam_node_address").Default("127.0.0.1:6262")).
 		Field(service.NewStringField("ockam_allow_producer").Default("self")).
-		Field(service.NewStringField("ockam_enrollement_ticket").Optional()).
+		Field(service.NewStringField("ockam_enrollment_ticket").Optional()).
 		Field(service.NewStringField("ockam_relay").Optional())
 }
 
@@ -50,8 +50,8 @@ func newOckamKafkaInput(conf *service.ParsedConfig, mgr *service.Resources) (*oc
 	// --- Create Ockam Node ----
 
 	var ticket string
-	if conf.Contains("ockam_enrollement_ticket") {
-		ticket, err = conf.FieldString("ockam_enrollement_ticket")
+	if conf.Contains("ockam_enrollment_ticket") {
+		ticket, err = conf.FieldString("ockam_enrollment_ticket")
 		if err != nil {
 			return nil, err
 		}

--- a/internal/impl/ockam/input_kafka.go
+++ b/internal/impl/ockam/input_kafka.go
@@ -17,7 +17,7 @@ func init() {
 			if err != nil {
 				return nil, err
 			}
-			return service.AutoRetryNacksBatchedToggled(conf, i.kafkaReader)
+			return service.AutoRetryNacksBatchedToggled(conf, i)
 		})
 	if err != nil {
 		panic(err)

--- a/internal/impl/ockam/input_kafka.go
+++ b/internal/impl/ockam/input_kafka.go
@@ -120,6 +120,9 @@ func newOckamKafkaInput(conf *service.ParsedConfig, mgr *service.Resources) (*oc
 	if err != nil {
 		return nil, err
 	}
+	if len(seedBrokers) > 1 {
+		mgr.Logger().Warn("ockam_kafka input only supports one seed broker")
+	}
 	bootstrapServer := strings.Split(seedBrokers[0], ",")[0]
 	// TODO: Handle more that one seed brokers
 

--- a/internal/impl/ockam/input_kafka.go
+++ b/internal/impl/ockam/input_kafka.go
@@ -1,0 +1,144 @@
+package ockam
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/benthosdev/benthos/v4/internal/impl/kafka"
+	"github.com/benthosdev/benthos/v4/public/service"
+)
+
+// this function is, almost, an exact copy of the init() function in ../kafka/input_kafka_franz.go
+func init() {
+	err := service.RegisterBatchInput("ockam_kafka", ockamKafkaInputConfig(),
+		func(conf *service.ParsedConfig, mgr *service.Resources) (service.BatchInput, error) {
+			i, err := newOckamKafkaInput(conf, mgr)
+			if err != nil {
+				return nil, err
+			}
+			return service.AutoRetryNacksBatchedToggled(conf, i.kafkaReader)
+		})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func ockamKafkaInputConfig() *service.ConfigSpec {
+	return kafka.FranzKafkaInputConfig().
+		Summary(`Ockam`).
+		Field(service.NewStringField("ockam_identity_name").Optional()).
+		Field(service.NewStringField("ockam_node_address").Default("127.0.0.1:6262")).
+		Field(service.NewStringField("ockam_allow_producer").Default("self")).
+		Field(service.NewStringField("ockam_enrollement_ticket").Optional()).
+		Field(service.NewStringField("ockam_relay").Optional())
+}
+
+//------------------------------------------------------------------------------
+
+type ockamKafkaInput struct {
+	node        node
+	kafkaReader *kafka.FranzKafkaReader
+}
+
+func newOckamKafkaInput(conf *service.ParsedConfig, mgr *service.Resources) (*ockamKafkaInput, error) {
+	_, err := setupCommand()
+	if err != nil {
+		return nil, err
+	}
+
+	// --- Create Ockam Node ----
+
+	var ticket string
+	if conf.Contains("ockam_enrollement_ticket") {
+		ticket, err = conf.FieldString("ockam_enrollement_ticket")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var relay string
+	if conf.Contains("ockam_relay") {
+		relay, err = conf.FieldString("ockam_relay")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var identityName string
+	if conf.Contains("ockam_identity_name") {
+		identityName, err = conf.FieldString("ockam_identity_name")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	address, err := conf.FieldString("ockam_node_address")
+	if err != nil {
+		return nil, err
+	}
+
+	n, err := newNode(identityName, address, ticket, relay)
+	if err != nil {
+		return nil, err
+	}
+
+	// --- Create Ockam Kafka Inlet ----
+
+	allowProducer, err := conf.FieldString("ockam_allow_producer")
+	if err != nil {
+		return nil, err
+	}
+
+	kafkaInletAddress, err := findAvailableLocalTCPAddress()
+	if err != nil {
+		return nil, err
+	}
+	err = n.createKafkaInlet("benthos-kafka-inlet", kafkaInletAddress, "self", true, "self", "self", allowProducer, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// ---- Create Ockam Kafka Outlet ----
+
+	_, tls, err := conf.FieldTLSToggled("tls")
+	if err != nil {
+		tls = false
+	}
+	// TODO: Handle other tls fields in kafka franz
+
+	kafkaReader, err := kafka.NewFranzKafkaReaderFromConfig(conf, mgr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use the first "seed_brokers" field item as the bootstrapServer argument for Ockam.
+	seedBrokers, err := conf.FieldStringList("seed_brokers")
+	if err != nil {
+		return nil, err
+	}
+	bootstrapServer := strings.Split(seedBrokers[0], ",")[0]
+	// TODO: Handle more that one seed brokers
+
+	kafkaOutletName := "benthos-kafka-outlet"
+	err = n.createKafkaOutlet(kafkaOutletName, bootstrapServer, tls, "self")
+	if err != nil {
+		return nil, err
+	}
+
+	// Override the list of SeedBrokers that would be used by kafka_franz, set it to the address of the kafka inlet
+	kafkaReader.SeedBrokers = []string{kafkaInletAddress}
+	return &ockamKafkaInput{*n, kafkaReader}, nil
+}
+
+func (o *ockamKafkaInput) Connect(ctx context.Context) error {
+	return o.kafkaReader.Connect(ctx)
+}
+
+func (o *ockamKafkaInput) ReadBatch(ctx context.Context) (service.MessageBatch, service.AckFunc, error) {
+	return o.kafkaReader.ReadBatch(ctx)
+}
+
+func (o *ockamKafkaInput) Close(ctx context.Context) error {
+	return errors.Join(o.kafkaReader.Close(ctx), o.node.delete())
+}

--- a/internal/impl/ockam/input_kafka.go
+++ b/internal/impl/ockam/input_kafka.go
@@ -77,6 +77,9 @@ func newOckamKafkaInput(conf *service.ParsedConfig, mgr *service.Resources) (*oc
 	if err != nil {
 		return nil, err
 	}
+	if localTCPAddressIsTaken(address) {
+		return nil, errors.New("ockam_node_address '" + address + "' is already in use")
+	}
 
 	n, err := newNode(identityName, address, ticket, relay)
 	if err != nil {

--- a/internal/impl/ockam/node.go
+++ b/internal/impl/ockam/node.go
@@ -1,0 +1,208 @@
+package ockam
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+type node struct {
+	name       string
+	address    string
+	identity   string
+	identifier string
+	config     string
+}
+
+func newNode(identityName string, address string, ticket string, relay string) (*node, error) {
+	name := "benthos-" + generateName()
+
+	identity, identifier, err := getIdentity(identityName)
+	if err != nil {
+		return nil, err
+	}
+
+	configuration := map[string]interface{}{
+		"name":                 name,
+		"identity":             identity,
+		"tcp-listener-address": address,
+	}
+
+	if ticket != "" {
+		configuration["ticket"] = ticket
+		if relay != "" {
+			configuration["relay"] = relay
+		}
+	}
+
+	j, err := json.Marshal(configuration)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal node config to json string: %v", err)
+	}
+
+	node := &node{name: name, identity: identity, identifier: identifier, config: string(j)}
+
+	err = node.create()
+	if err != nil {
+		return nil, err
+	}
+
+	return node, nil
+}
+
+func (n *node) create() error {
+	_, _, err := runCommand(false, "node", "create", "--node-config", n.config)
+	return err
+}
+
+func (n *node) delete() error {
+	_, _, err := runCommand(false, "node", "delete", n.name, "--yes")
+	return err
+}
+
+// TODO: improve this function's interface
+func (n *node) createKafkaInlet(name string, from string, to string, avoidPublishing bool, routeToConsumer string, allowOutlet string, allowProducer string, allowConsumer string) error {
+	args := []string{"kafka-inlet", "create", "--addr", name, "--at", n.name, "--from", from, "--to", to}
+
+	if avoidPublishing {
+		args = append(args, "--avoid-publishing")
+	}
+
+	if routeToConsumer != "" {
+		args = append(args, "--consumer", routeToConsumer)
+	}
+
+	args = appendAllowArgs(args, "--allow", allowOutlet, n.identifier)
+	args = appendAllowArgs(args, "--allow-producer", allowProducer, n.identifier)
+	args = appendAllowArgs(args, "--allow-consumer", allowConsumer, n.identifier)
+
+	_, _, err := runCommand(true, args...)
+	return err
+}
+
+func (n *node) createKafkaOutlet(name string, bootstrapServer string, tls bool, allowInlet string) error {
+	args := []string{"kafka-outlet", "create", "--addr", name, "--at", n.name, "--bootstrap-server", bootstrapServer}
+
+	if tls {
+		args = append(args, "--tls")
+	}
+
+	if allowInlet != "" {
+		if allowInlet == "self" {
+			args = append(args, "--allow", "(= subject.identifier \""+n.identifier+"\")")
+		} else if rune(allowInlet[0]) == 'I' {
+			args = append(args, "--allow", "(= subject.identifier \""+allowInlet+"\")")
+		} else {
+			args = append(args, "--allow", allowInlet)
+		}
+	}
+
+	_, _, err := runCommand(false, args...)
+	return err
+}
+
+func generateName() string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	randomNumber := r.Intn(1 << 32)
+	return fmt.Sprintf("%08x", randomNumber)
+}
+
+func appendAllowArgs(args []string, flag string, value string, identifier string) []string {
+	if value != "" {
+		if value == "self" {
+			args = append(args, flag, "(= subject.identifier \""+identifier+"\")")
+		} else if rune(value[0]) == 'I' {
+			args = append(args, flag, "(= subject.identifier \""+value+"\")")
+		} else {
+			args = append(args, flag, value)
+		}
+	}
+
+	return args
+}
+
+func listIdentities() ([]map[string]interface{}, error) {
+	stdout, _, err := runCommand(true, "identity", "list", "--output", "json")
+	if err != nil {
+		return nil, err
+	}
+
+	var identities []map[string]interface{}
+	err = json.Unmarshal([]byte(stdout), &identities)
+	if err != nil {
+		return nil, err
+	}
+
+	return identities, nil
+}
+
+func findOrCreateDefaultIdentity() (string, string, error) {
+	identities, err := listIdentities()
+	if err != nil {
+		return "", "", err
+	}
+
+	for _, identity := range identities {
+		if identity["is_default"].(bool) {
+			return identity["name"].(string), identity["identifier"].(string), nil
+		}
+	}
+
+	_, _, err = runCommand(false, "identity", "create")
+	if err != nil {
+		return "", "", err
+	}
+
+	identities, err = listIdentities()
+	if err != nil {
+		return "", "", err
+	}
+
+	for _, identity := range identities {
+		if identity["is_default"].(bool) {
+			return identity["name"].(string), identity["identifier"].(string), nil
+		}
+	}
+
+	return "", "", errors.New("default identity not found")
+}
+
+func findOrCreateIdentityByName(identityName string) (string, string, error) {
+	identities, err := listIdentities()
+	if err != nil {
+		return "", "", err
+	}
+
+	for _, identity := range identities {
+		if identity["name"] == identityName {
+			return identityName, identity["identifier"].(string), nil
+		}
+	}
+
+	_, _, err = runCommand(false, "identity", "create", identityName)
+	if err != nil {
+		return "", "", err
+	}
+
+	identities, err = listIdentities()
+	if err != nil {
+		return "", "", err
+	}
+
+	for _, identity := range identities {
+		if identity["name"] == identityName {
+			return identityName, identity["identifier"].(string), nil
+		}
+	}
+
+	return "", "", errors.New("failed to create identity")
+}
+
+func getIdentity(identityName string) (string, string, error) {
+	if identityName != "" {
+		return findOrCreateIdentityByName(identityName)
+	}
+	return findOrCreateDefaultIdentity()
+}

--- a/internal/impl/ockam/node.go
+++ b/internal/impl/ockam/node.go
@@ -42,7 +42,7 @@ func newNode(identityName string, address string, ticket string, relay string) (
 		return nil, fmt.Errorf("failed to marshal node config to json string: %v", err)
 	}
 
-	node := &node{name: name, identity: identity, identifier: identifier, config: string(j)}
+	node := &node{name: name, address: address, identity: identity, identifier: identifier, config: string(j)}
 
 	err = node.create()
 	if err != nil {

--- a/internal/impl/ockam/output_kafka.go
+++ b/internal/impl/ockam/output_kafka.go
@@ -1,0 +1,147 @@
+package ockam
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/benthosdev/benthos/v4/internal/impl/kafka"
+	"github.com/benthosdev/benthos/v4/public/service"
+)
+
+// this function is, almost, an exact copy of the init() function in ../kafka/output_kafka_franz.go
+func init() {
+	err := service.RegisterBatchOutput("ockam_kafka", ockamKafkaOutputConfig(),
+		func(conf *service.ParsedConfig, mgr *service.Resources) (
+			output service.BatchOutput,
+			batchPolicy service.BatchPolicy,
+			maxInFlight int,
+			err error,
+		) {
+			if maxInFlight, err = conf.FieldInt("max_in_flight"); err != nil {
+				return
+			}
+			if batchPolicy, err = conf.FieldBatchPolicy("batching"); err != nil {
+				return
+			}
+			output, err = newOckamKafkaOutput(conf, mgr.Logger())
+			return
+		})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func ockamKafkaOutputConfig() *service.ConfigSpec {
+	return kafka.FranzKafkaOutputConfig().
+		Summary("Ockam").
+		Field(service.NewStringField("ockam_enrollement_ticket").Optional()).
+		Field(service.NewStringField("ockam_identity_name").Optional()).
+		Field(service.NewStringField("ockam_allow_consumer").Default("self")).
+		Field(service.NewStringField("ockam_route_to_consumer").Default("/ip4/127.0.0.1/tcp/6262"))
+}
+
+//------------------------------------------------------------------------------
+
+type ockamKafkaOutput struct {
+	kafkaWriter *kafka.FranzKafkaWriter
+	node        node
+}
+
+func newOckamKafkaOutput(conf *service.ParsedConfig, log *service.Logger) (*ockamKafkaOutput, error) {
+	_, err := setupCommand()
+	if err != nil {
+		return nil, err
+	}
+
+	// --- Create Ockam Node ----
+
+	var ticket string
+	if conf.Contains("ockam_enrollement_ticket") {
+		ticket, err = conf.FieldString("ockam_enrollement_ticket")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var identityName string
+	if conf.Contains("ockam_identity_name") {
+		identityName, err = conf.FieldString("ockam_identity_name")
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	address, err := findAvailableLocalTCPAddress()
+	if err != nil {
+		return nil, err
+	}
+
+	n, err := newNode(identityName, address, ticket, "")
+	if err != nil {
+		return nil, err
+	}
+
+	// --- Create Ockam Kafka Inlet ----
+
+	routeToConsumer, err := conf.FieldString("ockam_route_to_consumer")
+	if err != nil {
+		return nil, err
+	}
+
+	allowConsumer, err := conf.FieldString("ockam_allow_consumer")
+	if err != nil {
+		return nil, err
+	}
+
+	kafkaInletAddress, err := findAvailableLocalTCPAddress()
+	if err != nil {
+		return nil, err
+	}
+	err = n.createKafkaInlet("benthos-kafka-inlet", kafkaInletAddress, "self", true, routeToConsumer, "self", "", allowConsumer)
+	if err != nil {
+		return nil, err
+	}
+
+	// ---- Create Ockam Kafka Outlet ----
+
+	kafkaWriter, err := kafka.NewFranzKafkaWriterFromConfig(conf, log)
+	if err != nil {
+		return nil, err
+	}
+
+	// Use the first "seed_brokers" field item as the bootstrapServer argument for Ockam.
+	seedBrokers, err := conf.FieldStringList("seed_brokers")
+	if err != nil {
+		return nil, err
+	}
+	bootstrapServer := strings.Split(seedBrokers[0], ",")[0]
+	// TODO: Handle more that one seed brokers
+
+	_, tls, err := conf.FieldTLSToggled("tls")
+	if err != nil {
+		tls = false
+	}
+
+	kafkaOutletName := "benthos-kafka-outlet"
+	err = n.createKafkaOutlet(kafkaOutletName, bootstrapServer, tls, "self")
+	if err != nil {
+		return nil, err
+	}
+
+	// Override the list of SeedBrokers that would be used by kafka_franz, set it to the address of the kafka inlet
+	kafkaWriter.SeedBrokers = []string{kafkaInletAddress}
+	return &ockamKafkaOutput{kafkaWriter, *n}, nil
+}
+
+func (o *ockamKafkaOutput) Connect(ctx context.Context) error {
+	return o.kafkaWriter.Connect(ctx)
+}
+
+func (o *ockamKafkaOutput) WriteBatch(ctx context.Context, batch service.MessageBatch) error {
+	return o.kafkaWriter.WriteBatch(ctx, batch)
+}
+
+func (o *ockamKafkaOutput) Close(ctx context.Context) error {
+	return errors.Join(o.kafkaWriter.Close(ctx), o.node.delete())
+}

--- a/internal/impl/ockam/output_kafka.go
+++ b/internal/impl/ockam/output_kafka.go
@@ -35,7 +35,7 @@ func init() {
 func ockamKafkaOutputConfig() *service.ConfigSpec {
 	return kafka.FranzKafkaOutputConfig().
 		Summary("Ockam").
-		Field(service.NewStringField("ockam_enrollement_ticket").Optional()).
+		Field(service.NewStringField("ockam_enrollment_ticket").Optional()).
 		Field(service.NewStringField("ockam_identity_name").Optional()).
 		Field(service.NewStringField("ockam_allow_consumer").Default("self")).
 		Field(service.NewStringField("ockam_route_to_consumer").Default("/ip4/127.0.0.1/tcp/6262"))
@@ -57,8 +57,8 @@ func newOckamKafkaOutput(conf *service.ParsedConfig, log *service.Logger) (*ocka
 	// --- Create Ockam Node ----
 
 	var ticket string
-	if conf.Contains("ockam_enrollement_ticket") {
-		ticket, err = conf.FieldString("ockam_enrollement_ticket")
+	if conf.Contains("ockam_enrollment_ticket") {
+		ticket, err = conf.FieldString("ockam_enrollment_ticket")
 		if err != nil {
 			return nil, err
 		}

--- a/internal/impl/ockam/output_kafka.go
+++ b/internal/impl/ockam/output_kafka.go
@@ -115,6 +115,9 @@ func newOckamKafkaOutput(conf *service.ParsedConfig, log *service.Logger) (*ocka
 	if err != nil {
 		return nil, err
 	}
+	if len(seedBrokers) > 1 {
+		log.Warn("ockam_kafka output only supports one seed broker")
+	}
 	bootstrapServer := strings.Split(seedBrokers[0], ",")[0]
 	// TODO: Handle more that one seed brokers
 

--- a/public/components/all/package.go
+++ b/public/components/all/package.go
@@ -35,6 +35,7 @@ import (
 	_ "github.com/benthosdev/benthos/v4/public/components/nanomsg"
 	_ "github.com/benthosdev/benthos/v4/public/components/nats"
 	_ "github.com/benthosdev/benthos/v4/public/components/nsq"
+	_ "github.com/benthosdev/benthos/v4/public/components/ockam"
 	_ "github.com/benthosdev/benthos/v4/public/components/opensearch"
 	_ "github.com/benthosdev/benthos/v4/public/components/otlp"
 	_ "github.com/benthosdev/benthos/v4/public/components/prometheus"

--- a/public/components/ockam/package.go
+++ b/public/components/ockam/package.go
@@ -1,0 +1,6 @@
+package ockam
+
+import (
+	// Bring in the internal plugin definitions.
+	_ "github.com/benthosdev/benthos/v4/internal/impl/ockam"
+)


### PR DESCRIPTION
This can be useful with dynamically allocated brokers started with 'rpk container start'.