### PR TITLE
fix: do not pass tls option down to to the underlying kafka plugin

### DIFF
--- a/internal/impl/kafka/input_kafka_franz.go
+++ b/internal/impl/kafka/input_kafka_franz.go
@@ -135,7 +135,7 @@ type FranzKafkaReader struct {
 	clientID        string
 	rackID          string
 	consumerGroup   string
-	tlsConf         *tls.Config
+	TlsConf         *tls.Config
 	saslConfs       []sasl.Mechanism
 	checkpointLimit int
 	startFromOldest bool
@@ -236,7 +236,7 @@ func NewFranzKafkaReaderFromConfig(conf *service.ParsedConfig, res *service.Reso
 		return nil, err
 	}
 	if tlsEnabled {
-		f.tlsConf = tlsConf
+		f.TlsConf = tlsConf
 	}
 	if f.multiHeader, err = conf.FieldBool("multi_header"); err != nil {
 		return nil, err
@@ -636,8 +636,8 @@ func (f *FranzKafkaReader) Connect(ctx context.Context) error {
 		)
 	}
 
-	if f.tlsConf != nil {
-		clientOpts = append(clientOpts, kgo.DialTLSConfig(f.tlsConf))
+	if f.TlsConf != nil {
+		clientOpts = append(clientOpts, kgo.DialTLSConfig(f.TlsConf))
 	}
 
 	if f.regexPattern {

--- a/internal/impl/kafka/output_kafka_franz.go
+++ b/internal/impl/kafka/output_kafka_franz.go
@@ -126,7 +126,7 @@ type FranzKafkaWriter struct {
 	clientID         string
 	rackID           string
 	idempotentWrite  bool
-	tlsConf          *tls.Config
+	TlsConf          *tls.Config
 	saslConfs        []sasl.Mechanism
 	metaFilter       *service.MetadataFilter
 	partitioner      kgo.Partitioner
@@ -255,7 +255,7 @@ func NewFranzKafkaWriterFromConfig(conf *service.ParsedConfig, log *service.Logg
 		return nil, err
 	}
 	if tlsEnabled {
-		f.tlsConf = tlsConf
+		f.TlsConf = tlsConf
 	}
 	if f.saslConfs, err = saslMechanismsFromConfig(conf); err != nil {
 		return nil, err
@@ -281,8 +281,8 @@ func (f *FranzKafkaWriter) Connect(ctx context.Context) error {
 		kgo.Rack(f.rackID),
 		kgo.WithLogger(&kgoLogger{f.log}),
 	}
-	if f.tlsConf != nil {
-		clientOpts = append(clientOpts, kgo.DialTLSConfig(f.tlsConf))
+	if f.TlsConf != nil {
+		clientOpts = append(clientOpts, kgo.DialTLSConfig(f.TlsConf))
 	}
 	if f.partitioner != nil {
 		clientOpts = append(clientOpts, kgo.RecordPartitioner(f.partitioner))

--- a/internal/impl/ockam/input_kafka.go
+++ b/internal/impl/ockam/input_kafka.go
@@ -134,6 +134,8 @@ func newOckamKafkaInput(conf *service.ParsedConfig, mgr *service.Resources) (*oc
 
 	// Override the list of SeedBrokers that would be used by kafka_franz, set it to the address of the kafka inlet
 	kafkaReader.SeedBrokers = []string{kafkaInletAddress}
+	// TLS is used by Ockam's outlet only, the kafka_franz writer will communicate in plaintext with the Ockam's inlet
+	kafkaReader.TlsConf = nil
 	return &ockamKafkaInput{*n, kafkaReader}, nil
 }
 

--- a/internal/impl/ockam/output_kafka.go
+++ b/internal/impl/ockam/output_kafka.go
@@ -134,6 +134,8 @@ func newOckamKafkaOutput(conf *service.ParsedConfig, log *service.Logger) (*ocka
 
 	// Override the list of SeedBrokers that would be used by kafka_franz, set it to the address of the kafka inlet
 	kafkaWriter.SeedBrokers = []string{kafkaInletAddress}
+	// TLS is used by Ockam's outlet only, the kafka_franz writer will communicate in plaintext with the Ockam's inlet
+	kafkaWriter.TlsConf = nil
 	return &ockamKafkaOutput{kafkaWriter, *n}, nil
 }
 


### PR DESCRIPTION
- Redpanda: you need to create a user in the dashboard and create an ACL with allow-all permissions for that user. Note the `sasl mechanism` is `SCRAM-SHA-256`. 
- Confluent: you need to create an API key in the dashboard. If you open one of the code examples in the dashboard, you will see the credentials you need. In this case, the `sasl mechanism` is `PLAIN`.


```yaml
# consumer.yaml

input:
  ockam_kafka:
    topics: [topic_A]
    consumer_group: example_group
    ockam_allow_producer: producer
    ockam_relay: consumer_relay
    ockam_enrollment_ticket: ${OCKAM_ENROLLMENT_TICKET}
    tls:
      enabled: true
    seed_brokers: [cpc4plcak824r7elle0g.any.eu-central-1.mpx.prd.cloud.redpanda.com:9092]
    sasl:
      - mechanism: "SCRAM-SHA-256"
        username: "admin"
        password: "admin"
#    seed_brokers: [pkc-12576z.us-west2.gcp.confluent.cloud:9092]
#    sasl:
#      - mechanism: "PLAIN"
#        username: "QTL3GPGNQ7NS3ICK"
#        password: "lzXxYwt0GAz2OfZZh3KDY2VpjTs6oMNMSrcNVwhaHe8vzoOmfy+SGyNP1gPI7ABY"

pipeline:
  processors:
    - bloblang: |
        root = this
        root.data.message = this.data.message.uppercase()

output:
  stdout: {}
```

```yaml
# producer.yaml

input:
  generate:
    count: 1000
    interval: "@every 1s"
    mapping: |
      root = {
        "_producer": hostname(),
        "data": { "email": fake("email"), "message": fake("sentence") }
      }

output:
  ockam_kafka:
    topic: topic_A
    ockam_route_to_consumer: /project/default/service/forward_to_consumer_relay/secure/api
    ockam_allow_consumer: consumer
    ockam_enrollment_ticket: ${OCKAM_ENROLLMENT_TICKET}
    tls:
      enabled: true
    seed_brokers: [cpc4plcak824r7elle0g.any.eu-central-1.mpx.prd.cloud.redpanda.com:9092]
    sasl:
      - mechanism: "SCRAM-SHA-256"
        username: "admin"
        password: "admin"
#    seed_brokers: [pkc-12576z.us-west2.gcp.confluent.cloud:9092]
#    sasl:
#      - mechanism: "PLAIN"
#        username: "QTL3GPGNQ7NS3ICK"
#        password: "lzXxYwt0GAz2OfZZh3KDY2VpjTs6oMNMSrcNVwhaHe8vzoOmfy+SGyNP1gPI7ABY"
```

```bash
# admin
ockam reset -y
ockam enroll --authorization-code-flow

ockam project ticket --usage-count 1 --expires-in 10m --attribute consumer --relay consumer_relay > consumer.ticket
ockam project ticket --usage-count 1 --expires-in 10m --attribute producer > producer.ticket

# consumer
export OCKAM_HOME=/tmp/consumer
OCKAM_ENROLLMENT_TICKET="$(cat ticket)" redpanda-connect -c consumer.yaml

# producer
export OCKAM_HOME=/tmp/producer
OCKAM_ENROLLMENT_TICKET="$(cat ticket)" redpanda-connect -c producer.yaml

# cleanup
ockam node delete --all -y
killall redpanda-connect
killall ockam
```
